### PR TITLE
Refactor contract definition context with `ContractImplementation`

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -5,7 +5,7 @@ class StatusController < ApplicationController
 
     resp = EthscriptionSync.fetch_newer_ethscriptions(newest_ethscription.ethscription_id, 1, 1)
     
-    total_newer_ethscriptions = resp['total_newer_ethscriptions'].to_i - 1
+    total_newer_ethscriptions = resp['total_newer_ethscriptions'].to_i
         
     resp = {
       oldest_known_ethscription: oldest_ethscription,

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -49,6 +49,18 @@ class Contract < ApplicationRecord
     end
   end
   
+  def self.all_abis(deployable_only: false)
+    contract_classes = valid_contract_types
+
+    contract_classes.each_with_object({}) do |name, hash|
+      contract_class = "Contracts::#{name}".constantize
+
+      next if deployable_only && contract_class.is_abstract_contract
+
+      hash[contract_class.name] = contract_class.public_abi
+    end.transform_keys(&:demodulize)
+  end
+  
   def as_json(options = {})
     super(
       options.merge(

--- a/app/models/contract_call_receipt.rb
+++ b/app/models/contract_call_receipt.rb
@@ -10,7 +10,8 @@ class ContractCallReceipt < ApplicationRecord
     call_error: 1,
     deploy_error: 2,
     call_to_non_existent_contract: 3,
-    system_error: 4
+    system_error: 4,
+    json_parse_error: 5
   }
   
   before_validation :clear_logs_if_error#, :ensure_status

--- a/app/models/contract_implementation.rb
+++ b/app/models/contract_implementation.rb
@@ -1,0 +1,209 @@
+class ContractImplementation
+  include ContractErrors
+    
+  attr_reader :contract_record
+  
+  class << self
+    attr_accessor :state_variable_definitions, :parent_contracts, :events, :is_abstract_contract
+  end
+  
+  delegate :block, :tx, :esc, to: :current_transaction
+  delegate :current_transaction, :contract_id, to: :contract_record
+  
+  def initialize(contract_record)
+    @state_proxy = StateProxy.new(
+      contract_record,
+      contract_record.type.constantize.state_variable_definitions
+    )
+    
+    @contract_record = contract_record
+  end
+  
+  def self.abstract
+    @is_abstract_contract = true
+  end
+  
+  def self.state_variable_definitions
+    @state_variable_definitions ||= {}
+  end
+  
+  def self.parent_contracts
+    @parent_contracts ||= []
+  end
+  
+  def s
+    @state_proxy
+  end
+  
+  def state_proxy
+    @state_proxy
+  end
+  
+  def msg
+    @msg ||= ContractTransactionGlobals::Message.new
+  end
+  
+  def self.abi
+    @abi ||= AbiProxy.new(self)
+  end
+  
+  Type.value_types.each do |type|
+    define_singleton_method(type) do |*args|
+      define_state_variable(type, args)
+    end
+  end
+  
+  def self.mapping(*args)
+    key_type, value_type = args.first.first
+    metadata = {key_type: key_type, value_type: value_type}
+    type = Type.create(:mapping, metadata)
+    
+    if args.last.is_a?(Symbol)
+      define_state_variable(type, args)
+    else
+      type
+    end
+  end
+  
+  def self.array(*args)
+    value_type = args.first
+    metadata = {value_type: value_type}
+    type = Type.create(:array, metadata)
+    
+    define_state_variable(type, args)
+  end
+  
+  def require(condition, message)
+    unless condition
+      caller_location = caller_locations.detect { |l| l.path.include?('/app/models/contracts') }
+      file = caller_location.path.gsub(%r{.*app/models/contracts/}, '')
+      line = caller_location.lineno
+      
+      error_message = "#{message}. (#{file}:#{line})"
+      raise ContractError.new(error_message, self)
+    end
+  end
+  
+  def self.public_abi
+    abi.select do |name, details|
+      details.publicly_callable?
+    end
+  end
+  
+  def public_abi
+    self.class.public_abi
+  end
+  
+  def self.is(*constants)
+    self.parent_contracts += constants.map{|i| "Contracts::#{i}".safe_constantize}
+    self.parent_contracts = self.parent_contracts.uniq
+  end
+  
+  def self.linearize_contracts(contract, processed = [])
+    return [] if processed.include?(contract)
+  
+    new_processed = processed + [contract]
+  
+    return [contract] if contract.parent_contracts.empty?
+    linearized = [contract] + contract.parent_contracts.reverse.flat_map { |parent| linearize_contracts(parent, new_processed) }
+    linearized.uniq { |c| raise "Invalid linearization" if linearized.rindex(c) != linearized.index(c); c }
+  end
+  
+  def self.linearized_parents
+    linearize_contracts(self)[1..-1]
+  end
+  
+  def self.function(name, args, *options, returns: nil, &block)
+    abi.create_and_add_function(name, args, *options, returns: returns, &block)
+  end
+  
+  def self.constructor(args, *options, &block)
+    function(:constructor, args, *options, returns: nil, &block)
+  end
+  
+  def self.event(name, args)
+    @events ||= {}
+    @events[name] = args
+  end
+
+  def self.events
+    @events || {}.with_indifferent_access
+  end
+
+  def emit(event_name, args = {})
+    unless self.class.events.key?(event_name)
+      raise ContractDefinitionError.new("Event #{event_name} is not defined in this contract.", self)
+    end
+
+    expected_args = self.class.events[event_name]
+    missing_args = expected_args.keys - args.keys
+    extra_args = args.keys - expected_args.keys
+
+    if missing_args.any? || extra_args.any?
+      error_messages = []
+      error_messages << "Missing arguments for #{event_name} event: #{missing_args.join(', ')}." if missing_args.any?
+      error_messages << "Unexpected arguments provided for #{event_name} event: #{extra_args.join(', ')}." if extra_args.any?
+      raise ContractDefinitionError.new(error_messages.join(' '), self)
+    end
+
+    current_transaction.log_event({ event: event_name, data: args })
+  end
+
+  def self.define_state_variable(type, args)
+    name = args.last.to_sym
+    type = Type.create(type)
+    
+    if state_variable_definitions[name]
+      raise "No shadowing: #{name} is already defined."
+    end
+    
+    state_variable_definitions[name] = { type: type, args: args }
+    
+    state_var = StateVariable.create(name, type, args)
+    state_var.create_public_getter_function(self)
+  end
+  
+  def self.pragma(*args)
+    # Do nothing for now
+  end
+  
+  def keccak256(input)
+    str = TypedVariable.create(:string, input)
+    
+    "0x" + Digest::Keccak256.new.hexdigest(str.value)
+  end
+  
+  protected
+
+  def string(i)
+    if i.is_a?(TypedVariable) && i.type.is_value_type?
+      return TypedVariable.create(:string, i.value.to_s)
+    else
+      raise "Input must be typed"
+    end
+  end
+  
+  def address(i)
+    return TypedVariable.create(:address) if i == 0
+
+    if i.is_a?(TypedVariable) && i.type == Type.create(:addressOrDumbContract)
+      return TypedVariable.create(:address, i.value)
+    end
+    
+    raise "Not implemented"
+  end
+  
+  def addressOrDumbContract(i)
+    return TypedVariable.create(:addressOrDumbContract) if i == 0
+    raise "Not implemented"
+  end
+  
+  def DumbContract(contract_id)
+    current_transaction.create_execution_context_for_call(contract_id, self.contract_id)
+  end
+  
+  def dumbContractId(i)
+    return contract_id if i == self
+    raise "Not implemented"
+  end
+end

--- a/app/models/contract_proxy.rb
+++ b/app/models/contract_proxy.rb
@@ -20,7 +20,7 @@ class ContractProxy
   end
 
   def define_contract_methods
-    filtered_abi = contract.public_abi.select do |name, func|
+    filtered_abi = contract.implementation.public_abi.select do |name, func|
       case operation
       when :static_call
         func.read_only?
@@ -31,9 +31,9 @@ class ContractProxy
       end
     end
     
-    filtered_abi.each do |name, _|
+    filtered_abi.each do |name, func|
       define_singleton_method(name) do |args|
-        contract.execute_function(name, args)
+        contract.execute_function(name, args, persist_state: !func.read_only?)
       end
     end
   end

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -63,9 +63,12 @@ class ContractTransaction
     begin
       data = JSON.parse(ethscription.content)
     rescue JSON::ParserError => e
-      return call_receipt.update!(
+      call_receipt.update!(
+        status: :json_parse_error,
         error_message: "JSON::ParserError: #{e.message}"
       )
+      
+      return
     end
     
     self.function_name = is_deploy? ? :constructor : data['functionName']

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -117,7 +117,10 @@ class ContractTransaction
       raise TransactionError.new("Cannot deploy abstract contract: #{contract_protocol}")
     end
     
-    new_contract = contract_class.create!(contract_id: ethscription.ethscription_id)
+    new_contract = Contract.create!(
+      contract_id: ethscription.ethscription_id,
+      type: contract_class,
+    )
     
     self.contract_id = new_contract.contract_id
   end

--- a/app/models/contracts/erc20.rb
+++ b/app/models/contracts/erc20.rb
@@ -1,4 +1,4 @@
-class Contracts::ERC20 < Contract
+class Contracts::ERC20 < ContractImplementation
   pragma :rubidity, "1.0.0"
   
   abstract

--- a/app/models/contracts/erc20_liquidity_pool.rb
+++ b/app/models/contracts/erc20_liquidity_pool.rb
@@ -1,4 +1,4 @@
-class Contracts::ERC20LiquidityPool < Contract
+class Contracts::ERC20LiquidityPool < ContractImplementation
   dumbContract :public, :token0
   dumbContract :public, :token1
   

--- a/app/models/contracts/erc721.rb
+++ b/app/models/contracts/erc721.rb
@@ -1,4 +1,4 @@
-class Contracts::ERC721 < Contract
+class Contracts::ERC721 < ContractImplementation
   pragma :rubidity, "1.0.0"
 
   abstract

--- a/app/models/contracts/ether_erc20_bridge.rb
+++ b/app/models/contracts/ether_erc20_bridge.rb
@@ -1,4 +1,4 @@
-class Contracts::EtherERC20Bridge < Contract
+class Contracts::EtherERC20Bridge < ContractImplementation
   pragma :rubidity, "1.0.0"
   
   is :ERC20

--- a/app/models/contracts/ethscription_erc20_bridge.rb
+++ b/app/models/contracts/ethscription_erc20_bridge.rb
@@ -1,4 +1,4 @@
-class Contracts::EthscriptionERC20Bridge < Contract
+class Contracts::EthscriptionERC20Bridge < ContractImplementation
   pragma :rubidity, "1.0.0"
   
   is :ERC20

--- a/app/models/contracts/generative_erc721.rb
+++ b/app/models/contracts/generative_erc721.rb
@@ -1,4 +1,4 @@
-class Contracts::GenerativeERC721 < Contract
+class Contracts::GenerativeERC721 < ContractImplementation
   is :ERC721
   
   string :public, :generativeScript

--- a/app/models/contracts/open_edition_erc721.rb
+++ b/app/models/contracts/open_edition_erc721.rb
@@ -1,4 +1,4 @@
-class Contracts::OpenEditionERC721 < Contract
+class Contracts::OpenEditionERC721 < ContractImplementation
   is :ERC721
   
   string :public, :contentURI

--- a/app/models/contracts/public_mint_erc20.rb
+++ b/app/models/contracts/public_mint_erc20.rb
@@ -1,4 +1,4 @@
-class Contracts::PublicMintERC20 < Contract
+class Contracts::PublicMintERC20 < ContractImplementation
   is :ERC20
   
   uint256 :public, :maxSupply

--- a/app/models/state_proxy.rb
+++ b/app/models/state_proxy.rb
@@ -44,4 +44,5 @@ class StateProxy
       state_variables[var_name.to_sym].deserialize(value)
     end
   end
+  alias_method :load, :deserialize
 end


### PR DESCRIPTION
To this point, contracts have been defined as subclasses of the `Contract` ActiveRecord class. Defining contracts and managing their persistence are different contexts and the shared namespace leads to conflicts.

For example, if we want to have an `address` function within contracts that allows us to write `emit :Transfer, from: address(0), to: to, amount: amount`, we cannot also have an `address` column on our contracts table because ActiveRecord automatically defines methods based on column names and we cannot have two methods called `address`.

This pull request fixes the situation by creating a new `ContractImplementation` class whose methods pertain (almost) exclusively to defining contracts.