### PR TITLE
Transaction Simulation

### DIFF
--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -6,10 +6,6 @@ class ContractsController < ApplicationController
 
     contracts = Contract.all.order(created_at: :desc).page(page).per(per_page)
 
-    # json = Rails.cache.fetch(contracts) do
-    #   contracts.to_a.as_json
-    # end
-
     render json: {
       result: contracts.map do |i|
         i.as_json.deep_transform_values do |value|
@@ -34,12 +30,6 @@ class ContractsController < ApplicationController
       render json: { error: "Contract not found" }, status: 404
       return
     end
-
-    # json = Rails.cache.fetch(contract) do
-    #   contract.as_json.deep_transform_values do |value|
-    #     value.is_a?(Integer) ? value.to_s : value
-    #   end
-    # end
 
     render json: {
       result: contract.as_json.deep_transform_values do |value|
@@ -107,5 +97,20 @@ class ContractsController < ApplicationController
         end
       end
     }
+  end
+  
+  def simulate_transaction
+    command = params[:command]
+    from = params[:from]
+    data = JSON.parse(params[:data])
+  
+    begin
+      receipt = ContractTransaction.simulate_transaction(command: command, from: from, data: data)
+    rescue => e
+      render json: { error: e.message }, status: 500
+      return
+    end
+  
+    render json: { result: receipt }
   end
 end

--- a/app/models/contract_call_receipt.rb
+++ b/app/models/contract_call_receipt.rb
@@ -29,7 +29,7 @@ class ContractCallReceipt < ApplicationRecord
   end
   
   def failed_deployment_contract_id
-    eth_transaction_id if deploy_error?
+    ethscription_id if deploy_error?
   end
   
   def as_json(options = {})

--- a/app/models/contract_state.rb
+++ b/app/models/contract_state.rb
@@ -12,7 +12,7 @@ class ContractState < ApplicationRecord
       super(
         options.merge(
           only: [
-            :eth_transaction_id,
+            :ethscription_id,
             :contract_id,
             :state,
           ]

--- a/app/models/contract_test_helper.rb
+++ b/app/models/contract_test_helper.rb
@@ -46,7 +46,8 @@ module ContractTestHelper
   )
     data = data.merge(salt: SecureRandom.hex)
     
-    uri = %{data:application/vnd.esc.contract.#{command}+json,#{data.to_json}}
+    mimetype = "data:application/vnd.esc.contract.#{command}+json"
+    uri = %{#{mimetype},#{data.to_json}}
     
     tx_hash = "0x" + SecureRandom.hex(32)
     sha = Digest::SHA256.hexdigest(uri)
@@ -67,7 +68,7 @@ module ContractTestHelper
       "transaction_index"=>transaction_index,
       "content_uri"=> uri,
       "content_sha"=>sha,
-      mimetype: "data:application/vnd.esc.contract.#{command}+json"
+      mimetype: mimetype
     }
     
     eth = Ethscription.create!(ethscription_attrs)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       get "/:contract_id/call-receipts/", to: "contracts#contract_call_receipts", constraints: { contract_id: /(0x)?[a-zA-Z0-9]{64}/ }
       get "/:contract_id/static-call/:function_name", to: "contracts#static_call", constraints: { contract_id: /(0x)?[a-zA-Z0-9]{64}/ }
       get "/call-receipts/:ethscription_id", to: "contracts#show_call_receipt", constraints: { transaction_hash: /(0x)?[a-zA-Z0-9]{64}/ }
+      get "/simulate/:command", to: "contracts#simulate_transaction"
       
       get "/all-abis", to: "contracts#all_abis"
       get "/deployable-contracts", to: "contracts#deployable_contracts"

--- a/spec/contracts_controller_spec.rb
+++ b/spec/contracts_controller_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe ContractsController, type: :controller do
+  describe 'GET #simulate_transaction' do
+    it 'simulates success' do
+      command = 'deploy'
+      from = "0xC2172a6315c1D7f6855768F843c420EbB36eDa97"
+      data = {
+        "protocol": "PublicMintERC20",
+        "constructorArgs": {
+          "name": "My Fun Token",
+          "symbol": "FUN",
+          "maxSupply": "21000000",
+          "perMintLimit": "1000",
+          "decimals": 18
+        },
+      }
+
+      get :simulate_transaction, params: {
+        command: command,
+        from: from,
+        data: data.to_json
+      }
+      
+      parsed = JSON.parse(response.body)
+      
+      expect(parsed['result']['status']).to eq('success')
+      
+      expect(response).to have_http_status(:success)
+    end
+    
+    it 'simulates failure' do
+      command = 'deploy'
+      from = "0xC2172a6315c1D7f6855768F843c420EbB36eDa97"
+      data = {
+        "protocol": "PublicMintERC20",
+        "constructorArgs": {
+          "name": "My Fun Token",
+          "symbol": "FUN",
+          "maxSupply": "21000000",
+          "perMintLimit": "1000",
+          "decimals": -18
+        },
+      }
+
+      get :simulate_transaction, params: {
+        command: command,
+        from: from,
+        data: data.to_json
+      }
+      
+      parsed = JSON.parse(response.body)
+      
+      expect(parsed['result']['status']).to eq('deploy_error')
+      
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Create an API endpoint that allows users to simulate transactions. The response of this endpoint will be the call receipt that would have been generated had the transaction not been a simulation.

The simulations are available at `/contracts/simulate/:command`, where `command` is either `deploy` or `call`.

Required URL params:

- from: the `msg.sender` of the simulated transaction.
- data: the data payload, i.e., the JSON part of the ethscription, including contract id, function name, and args. This should be JSON-encoded, just as it would be in the body of an ethscription.

For example, if

- from =`0xC2172a6315c1D7f6855768F843c420EbB36eDa97`
- data = `{"protocol":"PublicMintERC20","constructorArgs":{"name":"My+Fun+Token","symbol":"FUN","maxSupply":"21000000","perMintLimit":"1000","decimals":18}}`

The request path would be:

`/contracts/simulate/deploy?from=0xC2172a6315c1D7f6855768F843c420EbB36eDa97&data=%7B"protocol"%3A"PublicMintERC20"%2C"constructorArgs"%3A%7B"name"%3A"My+Fun+Token"%2C"symbol"%3A"FUN"%2C"maxSupply"%3A"21000000"%2C"perMintLimit"%3A"1000"%2C"decimals"%3A18%7D%7D`

And the response would be:

```json
{
	"result": {
		"contract_id": "0x4390e7d731752043c125d6cd3f6d5a915d443ce691c1f55ba82ed838653b216d",
		"ethscription_id": "0x4390e7d731752043c125d6cd3f6d5a915d443ce691c1f55ba82ed838653b216d",
		"caller": "0xc2172a6315c1d7f6855768f843c420ebb36eda97",
		"status": "success",
		"function_name": "constructor",
		"function_args": {
			"name": "My Fun Token",
			"symbol": "FUN",
			"decimals": 18,
			"maxSupply": "21000000",
			"perMintLimit": "1000"
		},
		"logs": [],
		"timestamp": "2023-09-01T17:09:34.373Z",
		"error_message": null,
		"failed_deployment_contract_id": null
	}
}
```

Internally, transaction simulation is implemented by creating a fake ethscription that generates the transactions, processing it, retrieving the call receipt, and rolling back all database changes.

The benefit of this approach is that the ethscription data persistence logic doesn't need to know about or deal with simulations:

```ruby

def self.simulate_transaction(
  command:,
  from:,
  data:
)
  data = data.merge(salt: SecureRandom.hex)

  mimetype = "data:application/vnd.esc.contract.#{command}+json"
  uri = %{#{mimetype},#{data.to_json}}

  ethscription_attrs = {
    ethscription_id: "0x" + SecureRandom.hex(32),
    block_number: 1e15.to_i,
    block_blockhash: "0x" + SecureRandom.hex(32),
    current_owner: from.downcase,
    creator: from.downcase,
    creation_timestamp: Time.zone.now,
    initial_owner: "0x" + "0" * 40,
    transaction_index: 0,
    content_uri: uri,
    content_sha: Digest::SHA256.hexdigest(uri),
    mimetype: mimetype
  }

  call_receipt = nil

  ActiveRecord::Base.transaction do
    eth = Ethscription.create!(ethscription_attrs)
    call_receipt = eth.contract_call_receipt

    raise ActiveRecord::Rollback
  end

  call_receipt
end
```