### PR TITLE
Enable the use of non-keyword function args

### DIFF
--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -22,10 +22,10 @@ class Contract < ApplicationRecord
     states.newest_first.first || ContractState.new
   end
   
-  def execute_function(function_name, function_args, persist_state:)
+  def execute_function(function_name, user_args, persist_state:)
     begin
       with_state_management(persist_state: persist_state) do
-        implementation.send(function_name.to_sym, function_args.deep_symbolize_keys)
+        implementation.send(function_name, *user_args[:args], **user_args[:kwargs])
       end
     rescue ContractError => e
       e.contract = self

--- a/app/models/contract_proxy.rb
+++ b/app/models/contract_proxy.rb
@@ -32,8 +32,9 @@ class ContractProxy
     end
     
     filtered_abi.each do |name, func|
-      define_singleton_method(name) do |args|
-        contract.execute_function(name, args, persist_state: !func.read_only?)
+      define_singleton_method(name) do |*args, **kwargs|
+        user_args = { args: args, kwargs: kwargs }
+        contract.execute_function(name, user_args, persist_state: !func.read_only?)
       end
     end
   end

--- a/app/models/contracts/erc20_liquidity_pool.rb
+++ b/app/models/contracts/erc20_liquidity_pool.rb
@@ -23,8 +23,8 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
   
   function :reserves, {}, :public, :view, returns: :string do
     jsonData = {
-      token0: DumbContract(s.token0).balanceOf(arg0: dumbContractId(this)),
-      token1: DumbContract(s.token1).balanceOf(arg0: dumbContractId(this))
+      token0: DumbContract(s.token0).balanceOf(dumbContractId(this)),
+      token1: DumbContract(s.token1).balanceOf(dumbContractId(this))
     }.to_json
     
     return "data:application/json,#{jsonData}"
@@ -35,8 +35,8 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
     outputToken: :dumbContract,
     inputAmount: :uint256
   }, :public, :view, returns: :uint256 do
-    inputReserve = DumbContract(inputToken).balanceOf(arg0: dumbContractId(this))
-    outputReserve = DumbContract(outputToken).balanceOf(arg0: dumbContractId(this))
+    inputReserve = DumbContract(inputToken).balanceOf(dumbContractId(this))
+    outputReserve = DumbContract(outputToken).balanceOf(dumbContractId(this))
     
     ((inputAmount * outputReserve) / (inputReserve + inputAmount)).to_i
   end
@@ -57,7 +57,7 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
       inputAmount: inputAmount
     )
     
-    outputReserve = DumbContract(outputToken).balanceOf(arg0: dumbContractId(this))
+    outputReserve = DumbContract(outputToken).balanceOf(dumbContractId(this))
     
     require(outputAmount <= outputReserve, "Insufficient output reserve")
   
@@ -68,8 +68,8 @@ class Contracts::ERC20LiquidityPool < ContractImplementation
     )
   
     DumbContract(outputToken).transfer(
-      to: msg.sender,
-      amount: outputAmount
+      msg.sender,
+      outputAmount
     )
   
     return outputAmount

--- a/app/models/contracts/erc721.rb
+++ b/app/models/contracts/erc721.rb
@@ -37,7 +37,7 @@ class Contracts::ERC721 < ContractImplementation
   function :approve, { spender: :addressOrDumbContract, id: :uint256 }, :public, :virtual do
     owner = s._ownerOf[id];
     
-    require(msg.sender == owner || isApprovedForAll[owner][msg.sender], "NOT_AUTHORIZED");
+    require(msg.sender == owner || s.isApprovedForAll[owner][msg.sender], "NOT_AUTHORIZED");
     
     s.getApproved[id] = spender;
 

--- a/app/models/function_context.rb
+++ b/app/models/function_context.rb
@@ -29,7 +29,6 @@ class FunctionContext < BasicObject
   
   def self.define_and_call_function_method(contract, args, &block)
     context = new(contract, args)
-    # binding.pry
     context.define_singleton_method(:function_implementation, &block)
     context.function_implementation
   end

--- a/spec/models/contract_spec.rb
+++ b/spec/models/contract_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe Contract, type: :model do
         data: {
           "contractId": @creation_receipt.contract_id,
           "functionName": "mint",
-          "args": {
-            "amount": "5"
-          },
+          "args": ["5"],
         }
       )
     end
@@ -206,10 +204,10 @@ RSpec.describe Contract, type: :model do
         data: {
           "contractId": deploy.contract_id,
           functionName: "bridgeIn",
-          args: {
-            to: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
-            amount: 500,
-          }
+          args: [
+            "0xC2172a6315c1D7f6855768F843c420EbB36eDa97",
+            500
+          ]
         }
       )
       
@@ -228,9 +226,9 @@ RSpec.describe Contract, type: :model do
       balance = ContractTransaction.make_static_call(
         contract_id: deploy.contract_id,
         function_name: "balanceOf",
-        function_args: {
-          arg0: "0xC2172a6315c1D7f6855768F843c420EbB36eDa97"
-        }
+        function_args: [
+          "0xC2172a6315c1D7f6855768F843c420EbB36eDa97"
+        ]
       )
       # binding.pry
       expect(balance).to eq(400)
@@ -297,9 +295,9 @@ RSpec.describe Contract, type: :model do
       balance = ContractTransaction.make_static_call(
         contract_id: deploy.contract_id,
         function_name: "balanceOf",
-        function_args: {
-          arg0: dc_token_recipient
-        }
+        function_args: [
+          dc_token_recipient
+        ]
       )
       
       expect(balance).to eq(1000 * (10 ** 18))
@@ -319,9 +317,9 @@ RSpec.describe Contract, type: :model do
       balance = ContractTransaction.make_static_call(
         contract_id: deploy.contract_id,
         function_name: "balanceOf",
-        function_args: {
-          arg0: "0x3A3323d81e77f6a604314aE6278a7B6f4c580928"
-        }
+        function_args: [
+          "0x3A3323d81e77f6a604314aE6278a7B6f4c580928"
+        ]
       )
       # binding.pry
       expect(balance).to eq(0)
@@ -342,9 +340,9 @@ RSpec.describe Contract, type: :model do
       balance = ContractTransaction.make_static_call(
         contract_id: deploy.contract_id,
         function_name: "pendingWithdrawalEthscriptionToOwner",
-        function_args: {
-          arg0: "0xd63053076a037e25dd76b53b603ef6d6b3c490d030e80929f7f6e2c62d09e6f6"
-        }
+        function_args: [
+          "0xd63053076a037e25dd76b53b603ef6d6b3c490d030e80929f7f6e2c62d09e6f6"
+        ]
       )
       # binding.pry
       expect(balance).to eq("0x" + "0" * 40)
@@ -689,9 +687,9 @@ RSpec.describe Contract, type: :model do
       a = ContractTransaction.make_static_call(
         contract_id: token0.contract_id,
         function_name: "balanceOf",
-        function_args: {
-          arg0: "0xc2172a6315c1d7f6855768f843c420ebb36eda97"
-        }
+        function_args: [
+          "0xc2172a6315c1d7f6855768f843c420ebb36eda97"
+        ]
       )
       expect(a).to eq(300)
       
@@ -722,9 +720,7 @@ RSpec.describe Contract, type: :model do
       finalTokenBBalance = ContractTransaction.make_static_call(
         contract_id: token1.contract_id,
         function_name: "balanceOf",
-        function_args: {
-          arg0: "0xc2172a6315c1d7f6855768f843c420ebb36eda97"
-        }
+        function_args: "0xc2172a6315c1d7f6855768f843c420ebb36eda97"
       )
       
       expect(finalTokenBBalance).to be > 500

--- a/spec/models/rubidity_spec.rb
+++ b/spec/models/rubidity_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe AbiProxy::FunctionProxy, type: :model do
+  describe '#convert_args_to_typed_variables_struct' do
+    let(:function_proxy) do
+      described_class.new(
+        args: { arg1: :string, arg2: :uint256 },
+        state_mutability: :non_payable,
+        visibility: :internal,
+        type: :function
+      )
+    end
+
+    context 'when named parameters are passed' do
+      let(:args) { { arg1: 'test', arg2: 123 } }
+
+      it 'converts named parameters to typed variables struct' do
+        result = function_proxy.convert_args_to_typed_variables_struct([], args)
+        expect(result.arg1).to be_a(TypedVariable)
+        expect(result.arg2).to be_a(TypedVariable)
+      end
+    end
+
+    context 'when non-named parameters are passed' do
+      let(:args) { ['test', 123] }
+
+      it 'converts non-named parameters to typed variables struct' do
+        result = function_proxy.convert_args_to_typed_variables_struct(args, {})
+        expect(result.arg1).to be_a(TypedVariable)
+        expect(result.arg2).to be_a(TypedVariable)
+      end
+    end
+  end
+  
+  describe '#validate_arg_names' do
+    let(:function_proxy) do
+      described_class.new(
+        args: { arg1: :string, arg2: :uint256 },
+        state_mutability: :non_payable,
+        visibility: :internal,
+        type: :function
+      )
+    end
+
+    context 'when all required arguments are passed' do
+      let(:args) { { arg1: 'test', arg2: 123 } }
+
+      it 'does not raise an error' do
+        expect { function_proxy.validate_arg_names(args) }.not_to raise_error
+      end
+    end
+
+    context 'when a required argument is missing' do
+      let(:args) { { arg1: 'test' } }
+
+      it 'raises a ContractArgumentError' do
+        expect { function_proxy.validate_arg_names(args) }.to raise_error(ContractErrors::ContractArgumentError, /Missing arguments for: arg2/)
+      end
+    end
+
+    context 'when an unexpected argument is passed' do
+      let(:args) { { arg1: 'test', arg2: 123, arg3: 'unexpected' } }
+
+      it 'raises a ContractArgumentError' do
+        expect { function_proxy.validate_arg_names(args) }.to raise_error(ContractErrors::ContractArgumentError, /Unexpected arguments provided for: arg3/)
+      end
+    end
+    
+    context 'when all required arguments are passed as an array' do
+      let(:args) { ['test', 123] }
+
+      it 'does not raise an error' do
+        expect { function_proxy.validate_arg_names(args) }.not_to raise_error
+      end
+    end
+
+    context 'when a required argument is missing in the array' do
+      let(:args) { ['test'] }
+
+      it 'raises a ContractArgumentError' do
+        expect { function_proxy.validate_arg_names(args) }.to raise_error(ContractErrors::ContractArgumentError, /Missing arguments for: arg2/)
+      end
+    end
+
+    context 'when an extra argument is passed in the array' do
+      let(:args) { ['test', 123, 'unexpected'] }
+
+      it 'raises a ContractArgumentError' do
+        expect { function_proxy.validate_arg_names(args) }.to raise_error(ContractErrors::ContractArgumentError, /Unexpected arguments provided for: unexpected/)
+      end
+    end
+  end
+  describe '#convert_args_to_typed_variables_struct' do
+    let(:function_proxy) do
+      described_class.new(
+        args: { arg1: :string, arg2: :uint256 },
+        state_mutability: :non_payable,
+        visibility: :internal,
+        type: :function
+      )
+    end
+
+    context 'when named parameters are passed' do
+      let(:args) { { arg1: 'test', arg2: 123 } }
+
+      it 'converts named parameters to typed variables struct' do
+        result = function_proxy.convert_args_to_typed_variables_struct(args, {})
+        expect(result.arg1).to be_a(TypedVariable)
+        expect(result.arg2).to be_a(TypedVariable)
+      end
+    end
+
+    context 'when non-named parameters are passed' do
+      let(:args) { ['test', 123] }
+
+      it 'converts non-named parameters to typed variables struct' do
+        result = function_proxy.convert_args_to_typed_variables_struct(args, {})
+        expect(result.arg1).to be_a(TypedVariable)
+        expect(result.arg2).to be_a(TypedVariable)
+      end
+    end
+
+    context 'when a single string argument is passed' do
+      let(:args) { 'test' }
+
+      it 'converts the string argument to a typed variables struct' do
+        result = function_proxy.convert_args_to_typed_variables_struct([args, nil], {})
+        expect(result.arg1).to be_a(TypedVariable)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously you had to write `_mint(to: msg.sender, amount: amount)`. Now you can write `_mint(msg.sender, amount)`.

The old system was particularly annoying in the case of auto-generated getter functions which were automatically assigned argument names `arg0`, `arg1` etc.